### PR TITLE
feat(analytics): integrate GA4 for site

### DIFF
--- a/app/analytics-listener.tsx
+++ b/app/analytics-listener.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { pageview } from '@/app/lib/gtag';
+
+export default function AnalyticsListener() {
+  const pathname = usePathname();
+  const search = useSearchParams();
+
+  useEffect(() => {
+    if (!pathname) return;
+    
+    const query = search?.toString();
+    const url = query ? `${pathname}?${query}` : pathname;
+    pageview(url);
+  }, [pathname, search]);
+
+  return null;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,13 @@
 import type { Metadata } from "next";
+import Script from "next/script";
+import { Suspense } from "react";
+import AnalyticsListener from "./analytics-listener";
 import "./globals.css";
 
 const base =
   process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.visageaiconsulting.com";
+
+const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
 
 export const metadata: Metadata = {
   title: "Visage AI",
@@ -18,6 +23,30 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
+        {!!GA_ID && (
+          <>
+            <Script
+              src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+              strategy="afterInteractive"
+            />
+            <Script id="ga-init" strategy="afterInteractive">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${GA_ID}', {
+                  send_page_view: false,
+                  linker: {
+                    domains: ['www.visageaiconsulting.com','visageaiconsulting.com','kyo1988.github.io']
+                  }
+                });
+              `}
+            </Script>
+          </>
+        )}
+        <Suspense fallback={null}>
+          <AnalyticsListener />
+        </Suspense>
         {children}
       </body>
     </html>

--- a/app/lib/analytics.ts
+++ b/app/lib/analytics.ts
@@ -1,6 +1,16 @@
+import { gaEvent } from './gtag';
+
 export function track(id: string, payload: Record<string, any> = {}) {
   if (typeof window === 'undefined') return;
-  // GA4 等に差し替え想定。暫定は console で可視化。
+  
+  // 既存のconsoleログとカスタムイベントを維持
   console.log('[track]', id, payload);
   window.dispatchEvent(new CustomEvent('analytics', { detail: { id, ...payload }}));
+  
+  // GA4イベント送信を追加（エラーが発生しても既存機能に影響しないようtry/catchで囲む）
+  try {
+    gaEvent(id, payload);
+  } catch (error) {
+    console.warn('[analytics] GA4 event failed:', error);
+  }
 }

--- a/app/lib/gtag.ts
+++ b/app/lib/gtag.ts
@@ -1,0 +1,35 @@
+export const GA_ID = process.env.NEXT_PUBLIC_GA_ID || '';
+
+const canUseGtag = () => typeof window !== 'undefined' && Boolean(GA_ID);
+
+export const pageview = (path: string) => {
+  if (!canUseGtag()) return;
+  
+  // window.gtagが存在しない場合はdataLayerに直接push
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', 'page_view', { page_path: path });
+  } else {
+    // gtagがまだ読み込まれていない場合はdataLayerに直接push
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: 'page_view',
+      page_path: path
+    });
+  }
+};
+
+export const gaEvent = (name: string, params?: Record<string, any>) => {
+  if (!canUseGtag()) return;
+  
+  // window.gtagが存在しない場合はdataLayerに直接push
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', name, params || {});
+  } else {
+    // gtagがまだ読み込まれていない場合はdataLayerに直接push
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: name,
+      ...params
+    });
+  }
+};

--- a/types/gtag.d.ts
+++ b/types/gtag.d.ts
@@ -1,0 +1,8 @@
+export {};
+
+declare global {
+  interface Window {
+    dataLayer?: any[];
+    gtag?: (...args: any[]) => void;
+  }
+}


### PR DESCRIPTION
## Overview
This PR integrates Google Analytics 4 (GA4) into the Visage AI webapp using Next.js App Router.

## Changes Made

### Core Implementation
- **GA4 Integration**: Added Measurement ID G-CEPK4D6DJL with manual page_view tracking
- **Cross-domain Setup**: Configured linker domains for www.visageaiconsulting.com, visageaiconsulting.com, and kyo1988.github.io
- **TypeScript Support**: Added gtag type declarations for window.gtag and dataLayer

### New Files
- `app/lib/gtag.ts`: Core GA4 utility functions with dataLayer fallback
- `app/analytics-listener.tsx`: Automatic page view tracking on route changes
- `types/gtag.d.ts`: TypeScript declarations for GA4 globals

### Modified Files
- `app/layout.tsx`: Added GA4 script loading with send_page_view: false
- `app/lib/analytics.ts`: Integrated GA4 event sending with existing track() function

## Key Features

### Manual Page View Tracking
- Uses `send_page_view: false` to prevent automatic page views
- Implements custom page view tracking via AnalyticsListener
- Ensures initial pageview is sent even before gtag script loads

### Robust Error Handling
- dataLayer fallback when gtag is not yet loaded
- Try/catch blocks to prevent GA4 errors from affecting existing functionality
- Maintains existing console logging and custom events

### Cross-domain Support
- Configured linker domains for seamless tracking across multiple domains
- Ready for future multi-domain deployments

## Testing

### Local Development
1. Set `NEXT_PUBLIC_GA_ID=G-CEPK4D6DJL` in .env.local
2. Run `npm run dev`
3. Check Network tab for gtag/js loading
4. Verify window.dataLayer exists in console
5. Confirm page views appear in GA4 DebugView

### Build Verification
- ✅ `npm run lint` passes
- ✅ `npm run build` succeeds
- ✅ All pages generate successfully
- ✅ No TypeScript errors

## Acceptance Criteria Met
- [x] GA4 script loads only once when NEXT_PUBLIC_GA_ID is set
- [x] Manual page_view tracking works without duplication
- [x] CSR navigation triggers single page_view per route change
- [x] Events appear in GA4 DebugView
- [x] No conflicts with existing track() functionality
- [x] .env.local excluded from commits

## Environment Variables Required
- `NEXT_PUBLIC_GA_ID`: Set to G-CEPK4D6DJL for production