### PR TITLE
feat: refine PoC LP section design + IG launch copy v0

### DIFF
--- a/components/marketing/LandingV8.tsx
+++ b/components/marketing/LandingV8.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { track } from "@/app/lib/analytics";
 
 type Locale = "ja" | "en";
@@ -254,8 +254,33 @@ export default function LandingV8({ locale }: { locale: string }) {
   );
   const active = t.tabs.find((tab) => tab.id === activeTab) ?? t.tabs[0];
 
+  // Fire poc_section_view once when the section is at least 50% visible.
+  const pocSectionRef = useRef<HTMLElement | null>(null);
+  const pocViewedRef = useRef(false);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const node = pocSectionRef.current;
+    if (!node || pocViewedRef.current) return;
+    if (typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting && !pocViewedRef.current) {
+            pocViewedRef.current = true;
+            track("poc_section_view", { locale: lang });
+            observer.disconnect();
+            break;
+          }
+        }
+      },
+      { threshold: 0.5 },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [lang]);
+
   return (
-    <main className="bg-gradient-to-b from-white to-slate-50">
+    <main className="bg-gradient-to-b from-white via-sky-50/30 to-slate-50">
       <section className="mx-auto max-w-7xl px-4 pb-14 pt-10 sm:px-6 lg:px-8 lg:pt-14">
         <div className="grid gap-8 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm md:grid-cols-2 md:items-center md:p-10">
           <div>
@@ -398,70 +423,102 @@ export default function LandingV8({ locale }: { locale: string }) {
 
       <section
         id="poc-recruitment"
-        className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8"
-        onMouseEnter={() => track("poc_section_view", { locale: lang })}
+        ref={pocSectionRef}
+        className="relative mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8"
       >
-        <div className="rounded-3xl border border-sky-200 bg-sky-50 p-6 shadow-sm md:p-8">
-          <p className="inline-flex rounded-full bg-white px-3 py-1 text-xs font-semibold text-sky-700 ring-1 ring-sky-200">
-            {t.poc.eyebrow}
-          </p>
-          <h2 className="mt-4 text-2xl font-semibold leading-tight text-slate-900 sm:text-3xl">
-            {t.poc.title}
-          </h2>
-          <p className="mt-4 text-sm leading-7 text-slate-700 sm:text-base">
-            {t.poc.lead}
-          </p>
+        <div className="relative overflow-hidden rounded-[28px] border border-sky-100 bg-gradient-to-br from-sky-50 via-white to-rose-50/40 p-6 shadow-[0_10px_40px_-20px_rgba(2,132,199,0.25)] sm:p-8 md:p-12">
+          {/* Decorative soft blobs */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -right-24 -top-24 h-72 w-72 rounded-full bg-sky-200/40 blur-3xl"
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -bottom-24 -left-16 h-64 w-64 rounded-full bg-rose-200/30 blur-3xl"
+          />
 
-          <div className="mt-6 grid gap-4 md:grid-cols-3">
-            <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-              <h3 className="text-sm font-semibold text-slate-900">
-                {t.poc.targetTitle}
-              </h3>
-              <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-700">
-                {t.poc.target.map((item) => (
-                  <li key={item}>・{item}</li>
-                ))}
-              </ul>
-            </article>
-            <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-              <h3 className="text-sm font-semibold text-slate-900">
-                {t.poc.validateTitle}
-              </h3>
-              <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-700">
-                {t.poc.validate.map((item) => (
-                  <li key={item}>・{item}</li>
-                ))}
-              </ul>
-            </article>
-            <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-              <h3 className="text-sm font-semibold text-slate-900">
-                {t.poc.effortTitle}
-              </h3>
-              <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-700">
-                {t.poc.effort.map((item) => (
-                  <li key={item}>・{item}</li>
-                ))}
-              </ul>
-            </article>
+          <div className="relative">
+            <div className="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-white/80 px-3 py-1 text-xs font-semibold tracking-wide text-sky-700 backdrop-blur">
+              <span className="relative flex h-2 w-2">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-sky-400 opacity-75" />
+                <span className="relative inline-flex h-2 w-2 rounded-full bg-sky-500" />
+              </span>
+              {t.poc.eyebrow}
+            </div>
+            <h2 className="mt-5 max-w-3xl text-[26px] font-semibold leading-[1.35] tracking-tight text-slate-900 sm:text-3xl md:text-[34px] md:leading-[1.3]">
+              {t.poc.title}
+            </h2>
+            <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-600 sm:text-base sm:leading-8">
+              {t.poc.lead}
+            </p>
+
+            <div className="mt-8 grid gap-4 md:grid-cols-3">
+              {(
+                [
+                  { num: "01", title: t.poc.targetTitle, items: t.poc.target },
+                  {
+                    num: "02",
+                    title: t.poc.validateTitle,
+                    items: t.poc.validate,
+                  },
+                  { num: "03", title: t.poc.effortTitle, items: t.poc.effort },
+                ] as const
+              ).map((card) => (
+                <article
+                  key={card.num}
+                  className="group relative rounded-2xl border border-slate-200/80 bg-white/90 p-5 shadow-sm backdrop-blur transition hover:-translate-y-0.5 hover:border-sky-200 hover:shadow-[0_12px_30px_-15px_rgba(2,132,199,0.25)]"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="inline-flex h-7 w-10 items-center justify-center rounded-full bg-gradient-to-br from-sky-500 to-sky-600 text-[11px] font-semibold tracking-wider text-white shadow-sm">
+                      {card.num}
+                    </span>
+                    <h3 className="text-sm font-semibold text-slate-900">
+                      {card.title}
+                    </h3>
+                  </div>
+                  <ul className="mt-4 space-y-2.5 text-sm leading-6 text-slate-700">
+                    {card.items.map((item) => (
+                      <li key={item} className="flex gap-2">
+                        <span
+                          aria-hidden
+                          className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-sky-400"
+                        />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </article>
+              ))}
+            </div>
+
+            <div className="mt-9 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+              <Link
+                href={`/${lang}/contact?utm_source=lp&utm_medium=poc_section&utm_campaign=poc_recruitment`}
+                onClick={() =>
+                  track("poc_cta_click", {
+                    placement: "poc_recruitment",
+                    locale: lang,
+                  })
+                }
+                className="group inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-br from-slate-900 to-slate-800 px-6 py-3.5 text-sm font-semibold text-white shadow-[0_8px_24px_-12px_rgba(15,23,42,0.6)] transition hover:from-slate-800 hover:to-slate-700 hover:shadow-[0_10px_28px_-10px_rgba(15,23,42,0.55)]"
+              >
+                {t.poc.cta}
+                <span
+                  aria-hidden
+                  className="transition-transform duration-200 group-hover:translate-x-0.5"
+                >
+                  →
+                </span>
+              </Link>
+              <span className="text-xs text-slate-600 sm:ml-1">
+                {t.poc.ctaSub}
+              </span>
+            </div>
+
+            <p className="mt-5 max-w-3xl text-xs leading-6 text-slate-500">
+              {t.poc.note}
+            </p>
           </div>
-
-          <div className="mt-6 flex flex-wrap items-center gap-3">
-            <Link
-              href={`/${lang}/contact?utm_source=lp&utm_medium=poc_section&utm_campaign=poc_recruitment`}
-              onClick={() =>
-                track("poc_cta_click", {
-                  placement: "poc_recruitment",
-                  locale: lang,
-                })
-              }
-              className="inline-flex items-center justify-center rounded-xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:opacity-90"
-            >
-              {t.poc.cta}
-            </Link>
-            <span className="text-xs text-slate-600">{t.poc.ctaSub}</span>
-          </div>
-
-          <p className="mt-4 text-xs leading-5 text-slate-500">{t.poc.note}</p>
         </div>
       </section>
 


### PR DESCRIPTION
# Refine PoC LP section design + Instagram launch copy v0

## Summary

PR #20 で追加した PoC 募集セクションを、美容・コスメ・ファッション・インバウンド小売向けに **より洗練された見た目** にリファインし、合わせて Instagram プロフィール / 固定投稿コピー v0 を `b2b_sales` 配下に整備した。

LP 全体の構造・コピーは変更していない。`components/marketing/LandingV8.tsx` の PoC 募集セクション周辺のみが対象。

## Changes

- `components/marketing/LandingV8.tsx`
  - PoC 募集セクションを再設計
    - 背景: `bg-sky-50` のフラットから、`bg-gradient-to-br from-sky-50 via-white to-rose-50/40` + 装飾用 soft blob 2 枚（sky / rose）への変更。美容・コスメ向けに上品な空気感を出しつつ、B2B SaaS の信頼感は維持。
    - eyebrow: ライブ感のある pulsing dot 付きピル UI に。
    - H2: tracking-tight + 行間調整 (`leading-[1.3]`) でブランド見出しらしさを強化。
    - カード: 番号バッジ (01 / 02 / 03) を sky グラデで表示。bullet を `・` 文字から sky-400 ドット要素に置き換え、視覚ノイズを減らした。`hover:-translate-y-0.5` + 影の強調で軽い触感を追加。
    - CTA: `bg-gradient-to-br from-slate-900 to-slate-800` + 矢印アイコン、ボタン影を強化。広告流入時にもファーストビュー比で目立つように。
    - スペーシング: `py-10` → `py-14`、内側 `p-6 / md:p-8` → `p-6 sm:p-8 md:p-12` に調整。スクロールリズム改善。
  - PoC セクションの view tracking を `onMouseEnter` から **IntersectionObserver (threshold 0.5, fire-once)** に変更。モバイルや高速スクロール時にも `poc_section_view` が正しく発火するようにし、SSR 安全 (`typeof window` ガード) を確認。
  - LP ルートの背景を `from-white via-sky-50/30 to-slate-50` に微調整。
- 既存 imports に `useEffect` / `useRef` を追加（`useState` 既存）。

LP 全体構造（hero / tabs / pricing / footer など）には触れていない。CTA リンク・UTM・`poc_cta_click` イベントは PR #20 のまま据え置き。

## Design rationale

- 美容・ファッション系の **上品で柔らかい** 空気感を出すために、淡いスカイ × うっすらローズの soft gradient + blur blob を採用。pink heavy / luxury 風には寄せず、B2B SaaS の落ち着いた信頼感は崩さない。
- 番号バッジ (01/02/03) を入れることで、3 つのカードが「対象 / 検証 / 負担」というプロセス的な構造として読み取りやすくなる。広告経由でじっくり読んでくれない層にも構造が伝わる。
- CTA はグラデ + 矢印で目線を集めるが、スカイブルー基調にして派手な広告ボタン感を避けた。

## Tracking

- `poc_section_view` (locale)
  - `onMouseEnter` → IntersectionObserver(0.5, once) に変更
  - モバイル発火を担保し、複数発火を抑制
- `poc_cta_click` (placement, locale)
  - 変更なし。CTA href / UTM も変更なし: `/${lang}/contact?utm_source=lp&utm_medium=poc_section&utm_campaign=poc_recruitment`
- Meta Pixel（`app/meta-pixel-listener.tsx`）は触っていない。本番カスタムドメインでの PageView のみという既存挙動を維持。

## Verification

- `npm run lint`: 通過（既存の関係ない警告のみ）
- `npm run build`: 成功
  - `/[locale]` 8.24 kB / 107 kB First Load JS（PR #20 時点 7.46 kB / 106 kB から +0.78 kB）
- TypeScript エラーなし

## Related artifacts

- `b2b_sales/docs/IG_PROFILE_AND_PINNED_POST_V0.md` を新規作成（このリポジトリ外、別ワークスペースで管理）
  - 想定アカウント: `@faceless_visage_ai`
  - Bio 案 5 種（PoC募集寄り / インバウンド寄り / コスメ寄り / 多言語寄り / 研究寄り）
  - 推奨採用は **PoC募集寄り**（LP の文言と一致）
  - 5 枚カルーセルの構成 / 画像内コピー / キャプション / ハッシュタグルール / Bio link UTM 推奨 (`?utm_source=instagram&utm_medium=bio&utm_campaign=poc_recruitment`)
- `b2b_sales/docs/HIGH_VALUE_MODEL_USAGE_PLAN_20260427.md` の T2 行を v0 完了として更新
- `b2b_sales/docs/SOGYO_GRANT_APPLICATION_STORY_V0.md` §4 LP/Webapp 運用 行に LP デザイン洗練 + IG コピー整備の追記

## Notes / risks

- LP の他セクション (hero / tabs / pricing) は意図的に未着手。次フェーズで広告 creative や IG カルーセルのテンプレと合わせて全体トンマナを引き上げる予定。
- 広告流入時の本物のファーストビュー検証は、Vercel Preview と本番デプロイ後に Mobile / Desktop 両方で改めて確認する。
- `poc_section_view` が IntersectionObserver 経由になったため、初回表示の数値が PR #20 比で変動する可能性あり。
