### PR TITLE
feat: refine LP visual design for premium Beauty-tech positioning

### DIFF
--- a/components/marketing/LandingV8.tsx
+++ b/components/marketing/LandingV8.tsx
@@ -9,9 +9,16 @@ type Locale = "ja" | "en";
 
 const copy = {
   ja: {
+    heroEyebrow: "Visage AI for Inbound Retail",
     heroTitle: "言葉の壁を超える、AI接客パートナー",
     heroLead:
       "インバウンド観光客の肌をAIで解析し、最適な商品提案までを多言語で支援。スタッフの接客力をデータで底上げします。",
+    heroPocLink: "PoC協力店舗 募集中",
+    heroTrust: [
+      "美容・コスメ・観光小売向け",
+      "多言語接客 (EN / ZH / KR / JA)",
+      "PoC協力店舗 募集中",
+    ],
     demo: "無料デモを予約する",
     whitepaper: "資料をダウンロード",
     problemsTitle: "あなたの店舗、こんなお悩みありませんか？",
@@ -112,9 +119,16 @@ const copy = {
     },
   },
   en: {
+    heroEyebrow: "Visage AI for Inbound Retail",
     heroTitle: "An AI sales partner for inbound retail",
     heroLead:
       "Visage AI analyzes guest skin conditions and supports multilingual product suggestions, so your staff can deliver consistent consultations.",
+    heroPocLink: "Now recruiting pilot stores",
+    heroTrust: [
+      "For beauty, cosmetics & tourism retail",
+      "Multilingual (EN / ZH / KR / JA)",
+      "Recruiting pilot stores",
+    ],
     demo: "Book a Free Demo",
     whitepaper: "Download Materials",
     problemsTitle: "Common retail challenges",
@@ -215,37 +229,6 @@ const copy = {
   },
 } as const;
 
-function CtaButtons({
-  locale,
-  primaryLabel,
-  secondaryLabel,
-  placement,
-}: {
-  locale: Locale;
-  primaryLabel: string;
-  secondaryLabel: string;
-  placement: string;
-}) {
-  return (
-    <div className="flex flex-wrap gap-3">
-      <Link
-        href={`/${locale}/demo`}
-        onClick={() => track("lp_demo_click", { placement, locale })}
-        className="inline-flex items-center justify-center rounded-xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:opacity-90"
-      >
-        {primaryLabel}
-      </Link>
-      <Link
-        href={`/${locale}/whitepaper/ebm-2025`}
-        onClick={() => track("lp_whitepaper_click", { placement, locale })}
-        className="inline-flex items-center justify-center rounded-xl border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-slate-800 hover:bg-slate-50"
-      >
-        {secondaryLabel}
-      </Link>
-    </div>
-  );
-}
-
 export default function LandingV8({ locale }: { locale: string }) {
   const lang: Locale = locale === "en" ? "en" : "ja";
   const t = copy[lang];
@@ -281,150 +264,323 @@ export default function LandingV8({ locale }: { locale: string }) {
 
   return (
     <main className="bg-gradient-to-b from-white via-sky-50/30 to-slate-50">
-      <section className="mx-auto max-w-7xl px-4 pb-14 pt-10 sm:px-6 lg:px-8 lg:pt-14">
-        <div className="grid gap-8 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm md:grid-cols-2 md:items-center md:p-10">
-          <div>
-            <p className="inline-flex rounded-full bg-sky-50 px-3 py-1 text-xs font-semibold text-sky-700">
-              Visage AI for Inbound Retail
-            </p>
-            <h1 className="mt-4 text-3xl font-bold leading-tight text-slate-900 sm:text-4xl">
-              {t.heroTitle}
-            </h1>
-            <p className="mt-4 text-sm leading-7 text-slate-600 sm:text-base">
-              {t.heroLead}
-            </p>
-            <div className="mt-6">
-              <CtaButtons
-                locale={lang}
-                primaryLabel={t.demo}
-                secondaryLabel={t.whitepaper}
-                placement="hero"
-              />
+      {/* ===== HERO ===== */}
+      <section className="relative overflow-hidden">
+        {/* Background decorative gradient */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[640px] bg-gradient-to-b from-sky-50/60 via-white to-transparent"
+        />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -left-32 top-32 -z-10 h-[420px] w-[420px] rounded-full bg-sky-200/30 blur-3xl"
+        />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -right-24 top-10 -z-10 h-[360px] w-[360px] rounded-full bg-rose-200/25 blur-3xl"
+        />
+
+        <div className="mx-auto max-w-7xl px-4 pb-16 pt-12 sm:px-6 lg:px-8 lg:pb-20 lg:pt-20">
+          <div className="grid gap-10 md:grid-cols-12 md:items-center md:gap-12">
+            <div className="md:col-span-7">
+              <div className="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-white/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-sky-700 backdrop-blur">
+                {t.heroEyebrow}
+              </div>
+              <h1 className="mt-5 text-[34px] font-semibold leading-[1.18] tracking-tight text-slate-900 sm:text-[42px] md:text-[52px] md:leading-[1.1]">
+                {t.heroTitle}
+              </h1>
+              <p className="mt-5 max-w-2xl text-base leading-[1.85] text-slate-600 sm:text-[17px]">
+                {t.heroLead}
+              </p>
+
+              <div className="mt-7 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+                <Link
+                  href={`/${lang}/demo`}
+                  onClick={() =>
+                    track("lp_demo_click", { placement: "hero", locale: lang })
+                  }
+                  className="group inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-br from-slate-900 to-slate-800 px-6 py-3.5 text-sm font-semibold text-white shadow-[0_8px_24px_-12px_rgba(15,23,42,0.6)] transition hover:from-slate-800 hover:to-slate-700 hover:shadow-[0_10px_28px_-10px_rgba(15,23,42,0.55)]"
+                >
+                  {t.demo}
+                  <span
+                    aria-hidden
+                    className="transition-transform duration-200 group-hover:translate-x-0.5"
+                  >
+                    →
+                  </span>
+                </Link>
+                <Link
+                  href={`/${lang}/whitepaper/ebm-2025`}
+                  onClick={() =>
+                    track("lp_whitepaper_click", {
+                      placement: "hero",
+                      locale: lang,
+                    })
+                  }
+                  className="inline-flex items-center justify-center rounded-xl border border-slate-300 bg-white px-5 py-3.5 text-sm font-semibold text-slate-800 transition hover:border-slate-400 hover:bg-slate-50"
+                >
+                  {t.whitepaper}
+                </Link>
+                <Link
+                  href="#poc-recruitment"
+                  onClick={() =>
+                    track("hero_poc_link_click", { locale: lang })
+                  }
+                  className="inline-flex items-center gap-1 text-sm font-medium text-sky-700 hover:text-sky-800 hover:underline"
+                >
+                  {t.heroPocLink}
+                  <span aria-hidden>→</span>
+                </Link>
+              </div>
+
+              <a
+                href="tel:+81-80-1180-8294"
+                className="mt-5 inline-flex text-sm font-medium text-slate-500 hover:text-slate-700"
+                onClick={() => track("phone_tap", { page: `/${lang}` })}
+              >
+                {t.phoneLabel}
+              </a>
+
+              {/* Trust strip */}
+              <ul className="mt-8 flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-slate-200/80 pt-5 text-xs font-medium text-slate-500">
+                {t.heroTrust.map((item) => (
+                  <li
+                    key={item}
+                    className="inline-flex items-center gap-2 tracking-wide"
+                  >
+                    <span
+                      aria-hidden
+                      className="h-1.5 w-1.5 shrink-0 rounded-full bg-sky-400"
+                    />
+                    {item}
+                  </li>
+                ))}
+              </ul>
             </div>
-            <a
-              href="tel:+81-80-1180-8294"
-              className="mt-4 inline-flex text-sm font-medium text-sky-700 hover:underline"
-              onClick={() => track("phone_tap", { page: `/${lang}` })}
-            >
-              {t.phoneLabel}
-            </a>
-          </div>
-          <div className="space-y-4">
-            <Image
-              src="/images/hero_inbound_v2.png"
-              alt="Visage AI iPad demo"
-              width={960}
-              height={720}
-              className="w-full rounded-2xl border border-slate-200 object-cover"
-              priority
-            />
-            <Image
-              src="/images/screens/staff_mode_v32.png"
-              alt="Show to Staff screen"
-              width={960}
-              height={720}
-              className="w-full rounded-2xl border border-slate-200 object-cover"
-            />
+
+            <div className="md:col-span-5">
+              <div className="relative">
+                <div
+                  aria-hidden
+                  className="absolute -inset-4 -z-10 rounded-[32px] bg-gradient-to-br from-sky-100/70 via-white to-rose-100/40 blur-2xl"
+                />
+                <div className="relative overflow-hidden rounded-[24px] border border-slate-200/80 bg-white shadow-[0_24px_60px_-30px_rgba(15,23,42,0.35)]">
+                  <Image
+                    src="/images/hero_inbound_v2.png"
+                    alt="Visage AI iPad demo"
+                    width={960}
+                    height={720}
+                    className="w-full object-cover"
+                    priority
+                  />
+                </div>
+                <div className="relative -mt-6 ml-8 hidden overflow-hidden rounded-[20px] border border-slate-200/80 bg-white shadow-[0_18px_45px_-25px_rgba(15,23,42,0.3)] sm:block sm:w-[68%]">
+                  <Image
+                    src="/images/screens/staff_mode_v32.png"
+                    alt="Show to Staff screen"
+                    width={960}
+                    height={720}
+                    className="w-full object-cover"
+                  />
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </section>
 
-      <section className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
-        <div className="grid gap-6 md:grid-cols-2">
-          <div className="rounded-2xl border border-rose-200 bg-rose-50 p-6">
-            <h2 className="text-xl font-semibold text-slate-900">
+      {/* ===== PROBLEMS / SOLUTIONS ===== */}
+      <section className="mx-auto max-w-7xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <span className="inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-600">
+            01 — Challenge &amp; Approach
+          </span>
+        </div>
+        <div className="mt-10 grid gap-6 md:grid-cols-2 md:gap-7">
+          <div className="relative overflow-hidden rounded-3xl border border-rose-100 bg-gradient-to-br from-rose-50/70 via-white to-white p-7 shadow-sm md:p-9">
+            <div className="inline-flex items-center gap-2 rounded-full border border-rose-200/80 bg-white/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-rose-700">
+              Challenges
+            </div>
+            <h2 className="mt-4 text-2xl font-semibold leading-tight text-slate-900 sm:text-[26px]">
               {t.problemsTitle}
             </h2>
-            <ul className="mt-4 space-y-3 text-sm text-slate-700">
+            <ul className="mt-5 space-y-3.5 text-sm leading-7 text-slate-700 sm:text-[15px]">
               {t.problems.map((problem) => (
-                <li key={problem}>❌ {problem}</li>
+                <li key={problem} className="flex gap-3">
+                  <span
+                    aria-hidden
+                    className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-400"
+                  />
+                  <span>{problem}</span>
+                </li>
               ))}
             </ul>
           </div>
-          <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-6">
-            <h2 className="text-xl font-semibold text-slate-900">
+          <div className="relative overflow-hidden rounded-3xl border border-sky-100 bg-gradient-to-br from-sky-50/80 via-white to-white p-7 shadow-sm md:p-9">
+            <div className="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-white/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-sky-700">
+              Visage AI Approach
+            </div>
+            <h2 className="mt-4 text-2xl font-semibold leading-tight text-slate-900 sm:text-[26px]">
               {t.solutionsTitle}
             </h2>
-            <ul className="mt-4 space-y-3 text-sm text-slate-700">
+            <ul className="mt-5 space-y-3.5 text-sm leading-7 text-slate-700 sm:text-[15px]">
               {t.solutions.map((solution) => (
-                <li key={solution}>✅ {solution}</li>
+                <li key={solution} className="flex gap-3">
+                  <span
+                    aria-hidden
+                    className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-sky-500"
+                  />
+                  <span>{solution}</span>
+                </li>
               ))}
             </ul>
           </div>
         </div>
       </section>
 
-      <section className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
-        <h2 className="text-2xl font-semibold text-slate-900">{t.effectsTitle}</h2>
-        <div className="mt-5 grid gap-4 md:grid-cols-2">
-          {t.effects.map((effect) => (
+      {/* ===== EFFECTS ===== */}
+      <section className="mx-auto max-w-7xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+        <div className="max-w-2xl">
+          <span className="inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-600">
+            02 — Outcomes
+          </span>
+          <h2 className="mt-4 text-3xl font-semibold leading-tight tracking-tight text-slate-900 sm:text-[34px]">
+            {t.effectsTitle}
+          </h2>
+        </div>
+        <div className="mt-10 grid gap-5 md:grid-cols-2 md:gap-6">
+          {t.effects.map((effect, idx) => (
             <article
               key={effect.title}
-              className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"
+              className="group relative overflow-hidden rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm transition hover:-translate-y-0.5 hover:border-sky-200 hover:shadow-[0_14px_36px_-18px_rgba(2,132,199,0.22)] md:p-7"
             >
-              <h3 className="text-base font-semibold text-slate-900">{effect.title}</h3>
-              <p className="mt-2 text-sm leading-7 text-slate-600">{effect.body}</p>
+              <div className="flex items-start gap-4">
+                <span className="inline-flex h-8 w-12 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-sky-500 to-sky-600 text-[11px] font-semibold tracking-[0.12em] text-white shadow-sm">
+                  {String(idx + 1).padStart(2, "0")}
+                </span>
+                <div>
+                  <h3 className="text-base font-semibold text-slate-900 sm:text-[17px]">
+                    {effect.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-7 text-slate-600">
+                    {effect.body}
+                  </p>
+                </div>
+              </div>
             </article>
           ))}
         </div>
       </section>
 
-      <section className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
-        <h2 className="text-2xl font-semibold text-slate-900">{t.industryTitle}</h2>
-        <div className="mt-5 flex flex-wrap gap-2">
-          {t.tabs.map((tab) => (
-            <button
-              key={tab.id}
-              type="button"
-              onClick={() => setActiveTab(tab.id as "cosmetics" | "inbound")}
-              className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
-                activeTab === tab.id
-                  ? "bg-slate-900 text-white"
-                  : "bg-white text-slate-700 border border-slate-300 hover:bg-slate-50"
-              }`}
-            >
-              {tab.label}
-            </button>
-          ))}
+      {/* ===== INDUSTRY TABS ===== */}
+      <section className="mx-auto max-w-7xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+        <div className="max-w-2xl">
+          <span className="inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-600">
+            03 — Use Cases
+          </span>
+          <h2 className="mt-4 text-3xl font-semibold leading-tight tracking-tight text-slate-900 sm:text-[34px]">
+            {t.industryTitle}
+          </h2>
         </div>
-        <article className="mt-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 className="text-lg font-semibold text-slate-900">{active.heading}</h3>
-          <ul className="mt-3 space-y-2 text-sm text-slate-700">
+        <div
+          role="tablist"
+          aria-label={t.industryTitle}
+          className="mt-8 inline-flex flex-wrap gap-2 rounded-full border border-slate-200 bg-white p-1.5 shadow-sm"
+        >
+          {t.tabs.map((tab) => {
+            const isActive = activeTab === tab.id;
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => setActiveTab(tab.id as "cosmetics" | "inbound")}
+                className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                  isActive
+                    ? "bg-gradient-to-br from-slate-900 to-slate-800 text-white shadow-sm"
+                    : "text-slate-600 hover:text-slate-900"
+                }`}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
+        <article className="mt-6 overflow-hidden rounded-3xl border border-slate-200/80 bg-white p-7 shadow-sm md:p-9">
+          <h3 className="text-xl font-semibold leading-snug text-slate-900 sm:text-[22px]">
+            {active.heading}
+          </h3>
+          <ul className="mt-5 grid gap-3 text-sm leading-7 text-slate-700 sm:text-[15px] md:grid-cols-3">
             {active.bullets.map((bullet) => (
-              <li key={bullet}>・{bullet}</li>
+              <li
+                key={bullet}
+                className="flex gap-3 rounded-2xl bg-sky-50/60 p-4"
+              >
+                <span
+                  aria-hidden
+                  className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-sky-500"
+                />
+                <span>{bullet}</span>
+              </li>
             ))}
           </ul>
         </article>
       </section>
 
-      <section className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
-        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm md:p-8">
-          <h2 className="text-2xl font-semibold text-slate-900">{t.transparencyTitle}</h2>
-          <p className="mt-3 text-sm leading-7 text-slate-600">{t.transparencyLead}</p>
-          <div className="mt-5 grid gap-4 md:grid-cols-2">
-            <Image
-              src="/images/screens/analysis_result_en.png"
-              alt="Skin Transparency result example"
-              width={840}
-              height={1180}
-              className="w-full rounded-2xl border border-slate-200 object-cover"
-            />
-            <Image
-              src="/images/screens/staff_card_ja.png"
-              alt="Staff recommendation guide example"
-              width={840}
-              height={1180}
-              className="w-full rounded-2xl border border-slate-200 object-cover"
-            />
+      {/* ===== SKIN TRANSPARENCY ===== */}
+      <section className="mx-auto max-w-7xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+        <div className="relative overflow-hidden rounded-[28px] border border-slate-200/80 bg-gradient-to-br from-white via-sky-50/40 to-rose-50/30 p-7 shadow-sm md:p-12">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -right-20 -top-20 h-64 w-64 rounded-full bg-sky-200/30 blur-3xl"
+          />
+          <div className="relative grid gap-10 md:grid-cols-12 md:gap-12 md:items-center">
+            <div className="md:col-span-5">
+              <span className="inline-flex items-center rounded-full border border-slate-200 bg-white/90 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-600">
+                04 — Technology
+              </span>
+              <h2 className="mt-4 text-3xl font-semibold leading-tight tracking-tight text-slate-900 sm:text-[32px]">
+                {t.transparencyTitle}
+              </h2>
+              <p className="mt-4 text-sm leading-7 text-slate-600 sm:text-[15px] sm:leading-[1.85]">
+                {t.transparencyLead}
+              </p>
+              <p className="mt-5 text-xs leading-6 text-slate-500">
+                {t.disclaimer}
+              </p>
+            </div>
+            <div className="md:col-span-7">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-[0_18px_45px_-25px_rgba(15,23,42,0.25)]">
+                  <Image
+                    src="/images/screens/analysis_result_en.png"
+                    alt="Skin Transparency result example"
+                    width={840}
+                    height={1180}
+                    className="w-full object-cover"
+                  />
+                </div>
+                <div className="overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-[0_18px_45px_-25px_rgba(15,23,42,0.25)] sm:mt-8">
+                  <Image
+                    src="/images/screens/staff_card_ja.png"
+                    alt="Staff recommendation guide example"
+                    width={840}
+                    height={1180}
+                    className="w-full object-cover"
+                  />
+                </div>
+              </div>
+            </div>
           </div>
-          <p className="mt-4 text-xs text-slate-500">{t.disclaimer}</p>
         </div>
       </section>
 
+      {/* ===== POC RECRUITMENT ===== */}
       <section
         id="poc-recruitment"
         ref={pocSectionRef}
-        className="relative mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8"
+        className="relative mx-auto max-w-7xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8"
       >
         <div className="relative overflow-hidden rounded-[28px] border border-sky-100 bg-gradient-to-br from-sky-50 via-white to-rose-50/40 p-6 shadow-[0_10px_40px_-20px_rgba(2,132,199,0.25)] sm:p-8 md:p-12">
           {/* Decorative soft blobs */}
@@ -438,12 +594,17 @@ export default function LandingV8({ locale }: { locale: string }) {
           />
 
           <div className="relative">
-            <div className="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-white/80 px-3 py-1 text-xs font-semibold tracking-wide text-sky-700 backdrop-blur">
-              <span className="relative flex h-2 w-2">
-                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-sky-400 opacity-75" />
-                <span className="relative inline-flex h-2 w-2 rounded-full bg-sky-500" />
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="inline-flex items-center rounded-full border border-slate-200 bg-white/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-600 backdrop-blur">
+                05 — Pilot
               </span>
-              {t.poc.eyebrow}
+              <span className="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-white/80 px-3 py-1 text-xs font-semibold tracking-wide text-sky-700 backdrop-blur">
+                <span className="relative flex h-2 w-2">
+                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-sky-400 opacity-75" />
+                  <span className="relative inline-flex h-2 w-2 rounded-full bg-sky-500" />
+                </span>
+                {t.poc.eyebrow}
+              </span>
             </div>
             <h2 className="mt-5 max-w-3xl text-[26px] font-semibold leading-[1.35] tracking-tight text-slate-900 sm:text-3xl md:text-[34px] md:leading-[1.3]">
               {t.poc.title}
@@ -522,22 +683,91 @@ export default function LandingV8({ locale }: { locale: string }) {
         </div>
       </section>
 
-      <section className="mx-auto max-w-7xl px-4 pb-16 pt-10 sm:px-6 lg:px-8">
-        <div className="rounded-3xl border border-slate-200 bg-slate-900 p-6 text-white md:p-8">
-          <h2 className="text-2xl font-semibold">{t.pricingTitle}</h2>
-          <ul className="mt-4 space-y-2 text-sm text-slate-100">
-            {t.pricingItems.map((item) => (
-              <li key={item}>・{item}</li>
-            ))}
-          </ul>
-          <p className="mt-3 text-xs text-slate-300">{t.pricingNote}</p>
-          <div className="mt-6">
-            <CtaButtons
-              locale={lang}
-              primaryLabel={t.demo}
-              secondaryLabel={t.whitepaper}
-              placement="pricing"
-            />
+      {/* ===== PRICING / FINAL CTA ===== */}
+      <section className="mx-auto max-w-7xl px-4 pb-20 pt-10 sm:px-6 lg:px-8">
+        <div className="relative overflow-hidden rounded-[28px] border border-slate-800 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800 p-7 text-white shadow-[0_30px_80px_-40px_rgba(15,23,42,0.7)] md:p-12">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -right-32 -top-32 h-72 w-72 rounded-full bg-sky-500/15 blur-3xl"
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -bottom-32 -left-24 h-72 w-72 rounded-full bg-rose-500/10 blur-3xl"
+          />
+          <div className="relative grid gap-10 md:grid-cols-12 md:gap-12 md:items-center">
+            <div className="md:col-span-7">
+              <span className="inline-flex items-center rounded-full border border-white/15 bg-white/5 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-sky-200 backdrop-blur">
+                06 — PoC Plan
+              </span>
+              <h2 className="mt-4 text-3xl font-semibold leading-tight tracking-tight sm:text-[34px]">
+                {t.pricingTitle}
+              </h2>
+              <ul className="mt-6 space-y-3 text-sm leading-7 text-slate-200 sm:text-[15px]">
+                {t.pricingItems.map((item) => (
+                  <li key={item} className="flex gap-3">
+                    <span
+                      aria-hidden
+                      className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-sky-400"
+                    />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-5 text-xs leading-6 text-slate-400">
+                {t.pricingNote}
+              </p>
+            </div>
+            <div className="md:col-span-5">
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur md:p-7">
+                <div className="flex flex-col gap-3">
+                  <Link
+                    href={`/${lang}/demo`}
+                    onClick={() =>
+                      track("lp_demo_click", {
+                        placement: "pricing",
+                        locale: lang,
+                      })
+                    }
+                    className="group inline-flex items-center justify-center gap-2 rounded-xl bg-white px-5 py-3.5 text-sm font-semibold text-slate-900 shadow-sm transition hover:bg-slate-100"
+                  >
+                    {t.demo}
+                    <span
+                      aria-hidden
+                      className="transition-transform duration-200 group-hover:translate-x-0.5"
+                    >
+                      →
+                    </span>
+                  </Link>
+                  <Link
+                    href={`/${lang}/contact?utm_source=lp&utm_medium=pricing_section&utm_campaign=poc_recruitment`}
+                    onClick={() =>
+                      track("poc_cta_click", {
+                        placement: "pricing_section",
+                        locale: lang,
+                      })
+                    }
+                    className="inline-flex items-center justify-center rounded-xl border border-white/20 bg-transparent px-5 py-3.5 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/5"
+                  >
+                    {t.poc.cta}
+                  </Link>
+                  <Link
+                    href={`/${lang}/whitepaper/ebm-2025`}
+                    onClick={() =>
+                      track("lp_whitepaper_click", {
+                        placement: "pricing",
+                        locale: lang,
+                      })
+                    }
+                    className="inline-flex items-center justify-center text-sm font-medium text-sky-200 hover:text-white"
+                  >
+                    {t.whitepaper}
+                    <span aria-hidden className="ml-1">
+                      →
+                    </span>
+                  </Link>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
# feat: refine LP visual design for premium Beauty-tech positioning

## Summary

PR #20（PoC募集セクション追加）/ PR #21（PoCセクションのデザイン洗練）に続き、**LP全体のトンマナを premium Beauty-tech / inbound retail intelligence / corporate trust の水準まで引き上げる徹底デザイン改善**。

PoC募集セクションだけが洗練されていて他セクションが業務SaaS寄りに見える状態を解消。Hero / Problems・Solutions / Effects / Industry Tabs / Skin Transparency / Final CTA すべてを共通デザイントークン（eyebrow pill / sky-400 ドットbullet / slate gradient CTA / 大きめ角丸 / soft shadow）で統一。

LP本文コピーは保持。新規追加は最小限（hero trust strip 3 項目 / hero PoC link 1 行のみ）。

## Sections changed

すべて `components/marketing/LandingV8.tsx` 内。

1. **Hero**
   - 1枚の白カード構造から、12カラムグリッド + 背景 soft gradient + 装飾 blur blob 2枚へ。
   - H1: `text-3xl/4xl` → `text-[34px] sm:text-[42px] md:text-[52px]` + `tracking-tight` + 行間 1.1。
   - サブコピー幅と行間を読みやすく調整 (`leading-[1.85]`)。
   - CTA 構成: Demo（slate gradient + arrow）/ Whitepaper（outlined）/ PoC anchor link（sky text-link、`#poc-recruitment` へ）。
   - 電話リンクを sky-700 underline → 落ち着いた slate-500 secondary へ降格。
   - ヒーロー画像を 2 枚スタック（メイン + ずらしオフセット）に再構成、薄い後光ガラデで奥行き付与。
   - **Trust strip**（border-top 区切り、sky-400 ドット）で「美容・コスメ・観光小売向け / 多言語 / PoC募集中」を一目訴求。
   - 新キー: `heroEyebrow` / `heroPocLink` / `heroTrust[]` を JA / EN に追加。
2. **Problems / Solutions**
   - eyebrow `01 — Challenge & Approach` セクションラベルを上部中央に。
   - 単色 rose-50 / emerald-50 のフラットカード 2 枚 → rose / sky を主軸にした gradient + sub eyebrow（`Challenges` / `Visage AI Approach`）+ refined heading + sky-400 / rose-400 ドット bullet。
   - ❌ / ✅ 絵文字を削除（B2C感を抑制）。
3. **Effects**
   - eyebrow `02 — Outcomes` を追加し H2 を `text-[34px]` に強化。
   - カードを 01/02/03/04 の sky グラデ番号バッジ + アイデンティティ統一 + hover lift。
4. **Industry Tabs**
   - eyebrow `03 — Use Cases` を追加。
   - タブを `rounded-full border bg-white p-1.5` segmented control 風に、active は slate gradient。
   - bullets を 3 カラム sky-50/60 のチップ風に変更。
5. **Skin Transparency**
   - eyebrow `04 — Technology` を追加。
   - 12 カラムレイアウトに変更（左: コピー / 右: 画像 2 枚を縦ずらし）。
   - 背景 gradient + blur blob で他セクションと統一。
6. **PoC Recruitment**
   - 既存の優れた構造（PR #21）を保持しつつ、`05 — Pilot` セクション番号 eyebrow を追加し全体の視覚リズムに同期。
   - スペーシング `py-14` → `py-16 sm:py-20` に統一。
7. **Final CTA / Pricing**
   - eyebrow `06 — PoC Plan`。
   - 単色 slate-900 → `from-slate-950 via-slate-900 to-slate-800` の上品なダーク gradient + sky/rose 微発光 blob で premium 感を強化。
   - 12 カラム構成: 左に PoC プラン箇条書き、右に **3 段 CTA カード（Demo / PoC相談 / 資料DL）** を配置。Demo は white solid、PoC相談は outlined、資料DL は subtle sky-200 link。CTA 階層が明確に。
   - PoC 相談の CTA は contact ページへ `utm_source=lp&utm_medium=pricing_section&utm_campaign=poc_recruitment` で遷移、トラッキングは `poc_cta_click` を `placement=pricing_section` で発火（PoCセクションの `placement=poc_recruitment` と区別可能）。
8. **その他**
   - 旧 `CtaButtons` ヘルパーは未使用化したため削除。
   - LP ルートの背景 gradient (`from-white via-sky-50/30 to-slate-50`) は維持。

## Design principles

- **white / slate / soft sky / faint rose** の落ち着いたパレット。pink heavy / D2C 風 / luxury 風には寄せない。
- **eyebrow pill** + **数字つきセクションラベル**（01〜06）でスクロール時のリズムと editorial 感を演出。
- **bullet は sky-400 ドット**、絵文字や `・` 記号は B2B 信頼感を弱めるため除去。
- **CTA 統一**: メイン CTA は `from-slate-900 to-slate-800` グラデ + 矢印 + soft shadow（PoCセクションと共通）。
- **カード統一**: `border-slate-200/80` + `shadow-sm` ベース、hover で `-translate-y-0.5` + sky 影が薄く立ち上がる。
- **角丸統一**: 大コンテナは `rounded-[28px]`、サブカードは `rounded-2xl`。
- **余白統一**: メジャーセクションは `py-16 sm:py-20`。
- **奥行き**: 各セクション少なくとも 1 つの `blur-3xl` decorative blob で空気感（強くなりすぎない `*/30` `*/40`）。

## Tracking / link preservation

- `poc_section_view`: PR #21 の IntersectionObserver(0.5, fire-once) を変更なしで保持。
- `poc_cta_click`: 既存（PoCセクション内、`placement=poc_recruitment`）+ 新規 Final CTA 内（`placement=pricing_section`）の 2 箇所で発火。両方とも contact UTM `utm_source=lp&utm_medium=poc_section|pricing_section&utm_campaign=poc_recruitment`。
- `lp_demo_click`: hero / pricing 双方で `placement` 属性を維持。
- `lp_whitepaper_click`: hero / pricing 双方で発火。
- `phone_tap`: 既存維持。
- 新規イベント: `hero_poc_link_click`（Hero の sky text-link 経由で PoC anchor にスクロールしたケース計測）。GA4 / `analytics` モジュールを通すため新規ライブラリ依存なし。
- Meta Pixel PageView: `app/meta-pixel-listener.tsx` 未変更。本番 custom domain 限定挙動を維持。
- ルート: `/[locale]` (ja / en) で i18n コピーは inline `copy` オブジェクトで切り替わる既存構造のまま。
- 既存 `/${lang}/demo` / `/${lang}/whitepaper/ebm-2025` / `/${lang}/contact` 全リンク維持。

## Mobile verification points

- Hero の 12 カラムは `md:` ブレークポイントで縦積みになるよう設計。`md` 未満では H1/サブコピー/CTA/trust strip → 画像 1 枚（2 枚目は `sm:hidden` 相当の `hidden ... sm:block` 制御）。
- CTA は `flex-col sm:flex-row sm:flex-wrap` で SP では縦積み、tap area は `py-3.5` を維持。
- セクション余白は SP で `py-16` を維持し詰まりすぎを回避。
- 各セクション H2 サイズは SP で `text-3xl` / `text-2xl`、PC で `text-[34px]` を維持。
- カード grid は `md:grid-cols-2/3` で SP は自然に縦積み。
- 英語表示で日本語より長くなる Effects / PoC タイトル等も `max-w-3xl` / `leading-[1.3]` で破綻なし。
- hero の trust strip は `flex-wrap gap-x-5 gap-y-2` で折り返しが崩れない。
- StickyHeader の高さ `h-16` 変更なし、Cookie banner / MobileStickyCta の挙動変更なし。

## lint / build

```
$ npm run lint
（LandingV8.tsx 関連の新規警告なし。既存の他ファイルの warnings のみ）

$ npm run build
✓ Compiled successfully
├ ƒ /[locale]                             9.32 kB         108 kB
（PR #21 時点 8.24 kB / 107 kB → +1.08 kB / +1 kB 増。decorative element 増による微増、許容範囲）
```

TypeScript: エラーなし。

## Screenshots / preview

GitHub Vercel preview チェック（5 deploy targets）通過後、以下を必ず手元確認:

- desktop `/ja` トップ → スクロール → 各セクションの eyebrow 番号が 01〜06 で連続表示されるか
- desktop `/en` トップ → 行幅崩れなし、CTA 文言英語切替確認
- mobile `/ja`（375 / 390 幅想定）→ Hero 1 画面に H1+サブコピー+CTA+trust strip まで収まるか / 過密でないか
- mobile `/en` → 同上
- Hero CTA → demo / whitepaper / `#poc-recruitment` anchor scroll
- Pricing CTA → demo / contact (`utm_medium=pricing_section`) / whitepaper

## Risks / follow-ups

- Final CTA の dark gradient はトーン強めなので、ブランド側で「もう少し白寄りにしたい」要望が出たら `from-slate-900 via-slate-800 to-slate-700` 等にトーンダウン余地あり。
- StickyHeader（`components/layout/StickyHeader.tsx`）はナビ項目数が多くこのままでは LP のシンプルな印象とトーンが食い違うので **次PR で別途整理推奨**（今回は対象外）。
- セクション番号 01〜06 は英字固定。日本語向けの「課題と解決」「成果」等の和文 eyebrow に置き換える設計余地あり（次回反応見て調整）。
- 1 件の新規イベント `hero_poc_link_click` は GA4 ダッシュボードに登録要。

## b2b_sales tracking

- `b2b_sales/docs/HIGH_VALUE_MODEL_USAGE_PLAN_20260427.md` T1 行に PR #21 / `feat/premium-lp-design-refresh` 進捗を追記。
- `b2b_sales/docs/SOGYO_GRANT_APPLICATION_STORY_V0.md` §4 LP/Webapp 行に LP 全体トンマナ刷新を 1 行追記。

## Self-evaluation

| # | 観点 | スコア (1-5) | 備考 |
|---|---|---|---|
| 1 | Beauty / fashion / cosmetics fit | 4 | sky × faint rose のソフト gradient で品位確保。コスメ実画像追加でさらに向上余地。 |
| 2 | Corporate trust | 5 | slate / sky 軸 + sober typography。PoC受け皿として十分。 |
| 3 | First-view impact | 4 | H1 拡大 + decorative blob + trust strip で改善。PC では右ビジュアル 2 枚スタックが効く。SP では trust strip まで一画面に入るかが境界線。 |
| 4 | CTA clarity | 5 | hero 3 段（demo / wp / poc anchor）、final 3 段（demo / poc / wp）の階層が明示的。 |
| 5 | Mobile quality | 4 | 縦積み破綻なし。SP の hero 二枚目画像は `hidden sm:block` で意図的に省略済み。 |
| 6 | Section rhythm | 5 | 01〜06 の番号 eyebrow で editorial 感統一。 |
| 7 | Visual consistency | 5 | tokens（eyebrow / dot bullet / gradient CTA / 角丸 / 影）で統一。 |
| 8 | PoC recruitment clarity | 5 | hero anchor / 専用セクション / Final CTA 3 段中央の 3 経路で導線確保。 |
| 9 | Performance risk | 4 | First Load JS +1 kB のみ。decorative element は CSS のみで画像追加なし。 |
| 10 | Implementation maintainability | 4 | 単一ファイル巨大化（500行強）は次回 split 候補（Hero.tsx / Section.tsx 分割案）。今回はあえて 1 ファイル維持で diff 可読性優先。 |
