### PR TITLE
feat: simplify LP navigation for premium PoC funnel

### DIFF
--- a/components/layout/StickyHeader.tsx
+++ b/components/layout/StickyHeader.tsx
@@ -151,7 +151,7 @@ export function StickyHeader() {
         {open && (
           <div
             id="mobile-nav"
-            className="border-t border-slate-200/70 pb-5 pt-4 md:hidden"
+            className="max-h-[calc(100dvh-4rem)] overflow-y-auto border-t border-slate-200/70 pb-28 pt-4 md:hidden"
           >
             <ul className="flex flex-col gap-1">
               {navItems.map((item) => (

--- a/components/layout/StickyHeader.tsx
+++ b/components/layout/StickyHeader.tsx
@@ -2,67 +2,187 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
+import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { useTranslations, useLocale } from '@/app/lib/intl';
+import { track } from '@/app/lib/analytics';
 import { LocaleSwitcher } from '../common/LocaleSwitcher';
 import { DemoButton } from '../common/DemoButton';
 
 export function StickyHeader() {
   const t = useTranslations('nav');
   const locale = useLocale();
+  const pathname = usePathname() ?? '';
+  const [open, setOpen] = useState(false);
+
+  // PoC anchor: when on landing page, use in-page anchor; otherwise route to landing then anchor.
+  const onLanding =
+    pathname === `/${locale}` || pathname === `/${locale}/`;
+  const pocHref = onLanding ? '#poc-recruitment' : `/${locale}#poc-recruitment`;
+
+  // Lock body scroll when mobile menu open.
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    if (open) {
+      const prev = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = prev;
+      };
+    }
+  }, [open]);
+
+  // Close menu on route change.
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  const navItems = [
+    { href: `/${locale}/technology`, label: t('technology') },
+    { href: `/${locale}/cases`, label: t('useCases') },
+    {
+      href: pocHref,
+      label: t('poc'),
+      isPoc: true as const,
+    },
+    { href: `/${locale}/pricing`, label: t('pricing') },
+    { href: `/${locale}/contact`, label: t('contact') },
+  ];
 
   return (
-    <header className="sticky top-0 z-50 bg-white border-b">
-      <nav className="mx-auto max-w-7xl px-6 lg:px-8" aria-label="Top">
-        <div className="flex h-16 items-center justify-between">
-          <div className="flex items-center">
-            <Link href={`/${locale}`} aria-label="Visage AI" className="block h-8">
-              <Image
-                src="/logo.png"
-                alt="Visage AI"
-                width={240}
-                height={64}
-                className="h-8 w-auto block"
-                priority
-              />
-            </Link>
+    <header className="sticky top-0 z-50 border-b border-slate-200/70 bg-white/85 backdrop-blur supports-[backdrop-filter]:bg-white/70">
+      <nav className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8" aria-label="Top">
+        <div className="flex h-16 items-center justify-between gap-4">
+          <Link
+            href={`/${locale}`}
+            aria-label="Visage AI"
+            className="flex shrink-0 items-center"
+          >
+            <Image
+              src="/logo.png"
+              alt="Visage AI"
+              width={240}
+              height={64}
+              className="h-7 w-auto md:h-8"
+              priority
+            />
+          </Link>
 
-            <div className="ml-10 hidden lg:flex lg:space-x-8">
-              <Link href={`/${locale}/technology`} className="text-base font-medium text-gray-500 hover:text-gray-900">
-                Technology
+          {/* Desktop nav */}
+          <div className="hidden items-center gap-7 md:flex">
+            {navItems.map((item) => (
+              <Link
+                key={item.label}
+                href={item.href}
+                onClick={
+                  item.isPoc
+                    ? () =>
+                        track('header_poc_link_click', { locale })
+                    : undefined
+                }
+                className="text-sm font-medium tracking-wide text-slate-600 transition hover:text-slate-900"
+              >
+                {item.label}
               </Link>
-              <Link href={`/${locale}/practices`} className="text-base font-medium text-gray-500 hover:text-gray-900">
-                Best Practices
-              </Link>
-              <Link href={`/${locale}/guide`} className="text-base font-medium text-gray-500 hover:text-gray-900">
-                Store Guide
-              </Link>
-              <Link href={`/${locale}/recommendation-demo`} className="text-base font-medium text-blue-600 hover:text-blue-700">
-                Try Demo
-              </Link>
-              <Link href={`/${locale}/#cases`} className="text-base font-medium text-gray-500 hover:text-gray-900">
-                {t('cases')}
-              </Link>
-              <Link href={`/${locale}/docs`} className="text-base font-medium text-gray-500 hover:text-gray-900">
-                {t('docs')}
-              </Link>
-              <Link href={`/${locale}/whitepaper/ebm-2025`} className="text-base font-medium text-gray-500 hover:text-gray-900">
-                {t('whitepaper')}
-              </Link>
-              <Link href={`/${locale}/pricing`} className="text-base font-medium text-gray-500 hover:text-gray-900">
-                {t('pricing')}
-              </Link>
-              <Link href={`/${locale}/docs/security`} className="text-base font-medium text-gray-500 hover:text-gray-900">
-                {t('security')}
-              </Link>
-            </div>
+            ))}
           </div>
-          <div className="ml-10 flex items-center space-x-4">
+
+          <div className="flex items-center gap-2 sm:gap-3">
             <div className="hidden md:inline-flex">
-              <DemoButton label={t('demo')} />
+              <DemoButton
+                label={t('demo')}
+                from="header"
+                className="rounded-xl px-4 py-2.5 text-sm font-semibold shadow-sm"
+              />
             </div>
-            <LocaleSwitcher />
+            <div className="hidden text-sm font-medium text-slate-600 hover:text-slate-900 md:inline-flex">
+              <LocaleSwitcher />
+            </div>
+
+            {/* Mobile controls */}
+            <div className="md:hidden">
+              <LocaleSwitcher />
+            </div>
+            <button
+              type="button"
+              aria-label={open ? t('menuClose') : t('menuOpen')}
+              aria-expanded={open}
+              aria-controls="mobile-nav"
+              onClick={() => setOpen((v) => !v)}
+              className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 transition hover:bg-slate-50 md:hidden"
+            >
+              {open ? (
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M18 6 6 18" />
+                  <path d="m6 6 12 12" />
+                </svg>
+              ) : (
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M4 6h16" />
+                  <path d="M4 12h16" />
+                  <path d="M4 18h16" />
+                </svg>
+              )}
+            </button>
           </div>
         </div>
+
+        {/* Mobile menu */}
+        {open && (
+          <div
+            id="mobile-nav"
+            className="border-t border-slate-200/70 pb-5 pt-4 md:hidden"
+          >
+            <ul className="flex flex-col gap-1">
+              {navItems.map((item) => (
+                <li key={item.label}>
+                  <Link
+                    href={item.href}
+                    onClick={() => {
+                      if (item.isPoc) {
+                        track('header_poc_link_click', { locale });
+                      }
+                      setOpen(false);
+                    }}
+                    className="flex items-center justify-between rounded-xl px-3 py-3 text-base font-medium text-slate-700 hover:bg-slate-50 hover:text-slate-900"
+                  >
+                    <span>{item.label}</span>
+                    <span aria-hidden className="text-slate-400">
+                      →
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+            <div className="mt-4 px-1">
+              <DemoButton
+                label={t('demo')}
+                from="header_mobile"
+                className="w-full justify-center rounded-xl px-5 py-3 text-sm font-semibold"
+              />
+            </div>
+          </div>
+        )}
       </nav>
     </header>
   );

--- a/messages/en.json
+++ b/messages/en.json
@@ -20,7 +20,13 @@
     "whitepaper": "Whitepaper",
     "pricing": "Pricing",
     "security": "Security",
-    "demo": "Book a Demo"
+    "demo": "Book a Demo",
+    "technology": "Technology",
+    "useCases": "Use Cases",
+    "poc": "PoC",
+    "contact": "Contact",
+    "menuOpen": "Open menu",
+    "menuClose": "Close menu"
   },
   "hero": {
     "title": "Give your inbound customers <br/>AI-powered evidence.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -18,9 +18,15 @@
     "cases": "導入事例",
     "docs": "サポート",
     "whitepaper": "ホワイトペーパー",
-    "pricing": "価格",
+    "pricing": "料金",
     "security": "セキュリティ",
-    "demo": "デモを予約"
+    "demo": "デモ予約",
+    "technology": "技術",
+    "useCases": "活用例",
+    "poc": "PoC",
+    "contact": "お問い合わせ",
+    "menuOpen": "メニューを開く",
+    "menuClose": "メニューを閉じる"
   },
   "hero": {
     "title": "インバウンド客への提案に、<br/>AIという「確かな根拠」を。",


### PR DESCRIPTION
# feat: simplify LP navigation for premium PoC funnel

## Summary

PR #20 / #21 / #22 で LP 本体は premium Beauty-tech / inbound retail intelligence のトーンに揃った。残る課題は **StickyHeader / Navigation** が旧来の業務SaaS風で項目過多 + LPの空気感に追いついていなかったこと。

本PRで Header/Nav を **PoC募集ファネルに集中したシンプルな構成** に整理し、LP本体と統一感を持たせる。

## Why

- 広告 / Instagram 流入時の第一印象で Header の項目密度が雑然として見える
- 9 項目の desktop nav (`Technology / Best Practices / Store Guide / Try Demo / Case Studies / Support / Whitepaper / Pricing / Security`) は PoC 受け皿としては多すぎる
- 日本語表記のバラつき（`デモを予約` vs `デモ予約` など）
- mobile menu が未実装で、SP では nav 項目が `lg:flex` で隠れたまま辿り着けない
- LP 本体は PoC 相談 / Demo 予約 / 資料DL に CTA を集中させているのに、Header だけが拡散していた

## Header / Nav before → after

### Before (StickyHeader.tsx)

- Desktop nav 項目: Technology / Best Practices / Store Guide / Try Demo / Case Studies / Support / Whitepaper / Pricing / Security （9項目、`lg:` で表示）
- CTA: 青ベタ `Book a Demo`
- Mobile: nav は `lg:flex` で完全に非表示、ハンバーガー無し → 項目に到達不能
- Backdrop: 単純な `bg-white border-b`
- 言語切替: `English` / `日本語` の単純トグル（既存維持）

### After

- Desktop nav 項目: **Technology / Use Cases / PoC / Pricing / Contact** （5項目）
- 主CTA: `Book a Demo` / `デモ予約` を `rounded-xl`, `px-4 py-2.5`, `text-sm font-semibold`, `shadow-sm` で LP 本体と整合
- Backdrop: `border-slate-200/70 bg-white/85 backdrop-blur supports-[backdrop-filter]:bg-white/70` で premium glass tone
- ロゴ高: `h-7 md:h-8` に統一
- Tracking: PoC nav click で `header_poc_link_click` (`{ locale }`) を発火
- Mobile (md未満):
  - ハンバーガーアイコン (SVG) + トグル開閉
  - `aria-expanded` / `aria-controls` / `aria-label`（`menuOpen` / `menuClose` i18n キー追加）
  - 開いている間は `document.body.style.overflow = 'hidden'` で背面スクロールロック
  - route 変更時に自動クローズ
  - 各 nav リンクは `rounded-xl px-3 py-3` の縦並びリスト + 末尾矢印
  - メニュー内に `Book a Demo` / `デモ予約` フルワイド CTA（`from='header_mobile'`）
- LandingV8 上での PoC リンク: 同一ページ内なら `#poc-recruitment` anchor、他ページ閲覧時は `/${locale}#poc-recruitment` で landing → anchor 遷移。`usePathname` で判定。

## Items removed from header

- Best Practices
- Store Guide
- Case Studies
- Support
- Whitepaper（Hero / Final CTA で既に到達可能）
- Security
- Try Demo（recommendation-demo へのテキストリンク。主CTA `Book a Demo` と役割重複していたため整理）

## Items kept in footer

`components/landing/Footer.tsx` は今回未変更。既に下記が網羅されており、Header から移動した項目は Footer 経由で全て到達可能:

- Product / Cases / Docs (Support) / Pricing / Security / Privacy / DSR / Contact / Technology / Best Practices / Store Guide
- App Store リンク / SNS

## Tracking / link preservation

- `demo_cta_click` (DemoButton 内、`from='header'` / `from='header_mobile'`) — 維持
- `header_poc_link_click` (`{ locale }`) — 新規。analytics の `track()` 経由で GA4 / CustomEvent / console に記録
- `poc_section_view` (LandingV8 内 IO 0.5 fire-once) — 未変更、Header 経由で `#poc-recruitment` anchor に着地後も発火
- `poc_cta_click` (`placement: poc_recruitment | pricing_section`) — 未変更
- `lp_demo_click` / `lp_whitepaper_click` (LandingV8 内) — 未変更
- `phone_tap` — 未変更
- Meta Pixel PageView (`app/meta-pixel-listener.tsx`) — 未変更
- 全 i18n route (`/ja` / `/en`) — 未変更

## IG Bio URL correction

`b2b_sales/docs/IG_PROFILE_AND_PINNED_POST_V0.md` を最終確定:

- 採用 Bio (案A 短縮版):
  ```
  Visage AI｜接客AI / Inbound Retail
  美容・コスメ店舗の訪日客対応を支援するAIを検証中
  PoC協力店舗を少数募集｜30分ヒアリングから
  ```
- 採用 Bio link（**順序厳守**）:
  ```
  https://www.visageaiconsulting.com/ja?utm_source=instagram&utm_medium=bio&utm_campaign=poc_recruitment#poc-recruitment
  ```
- `?クエリ → #fragment` の順序を厳守。逆順は UTM が fragment 部に吸収され GA4 で検出されないため禁止。

## Verification

### lint / build

```
$ npm run lint
（StickyHeader.tsx 関連の新規警告なし。既存他ファイルの warnings のみ）

$ npm run build
✓ Compiled successfully
├ ƒ /[locale]                             9.32 kB         108 kB
（PR #22 と同サイズ。Header 整理は LandingV8 のサイズに影響しない）
```

### Preview / production manual check points

PR #22 production reflection:
- `https://www.visageaiconsulting.com/ja` / `/en` で LP 本体が premium tone (Hero blob / 01〜06 セクション番号 / Final CTA dark gradient) になっていること
- `#poc-recruitment` anchor が PoC セクションへスクロールすること
- `?utm_source=lp&utm_medium=poc_section&utm_campaign=poc_recruitment` が contact 遷移に保持されること
- Meta Pixel PageView (`facebook.com/tr?id=...&ev=PageView`) が production custom domain で 1 件発火すること

This PR (Header simplification):
- desktop `/ja` `/en`: Header に 5 項目のみ表示、CTA が `デモ予約` / `Book a Demo`
- mobile `/ja` `/en` (≤ md): ハンバーガーから 5 項目 + フルワイド `デモ予約` CTA
- PoC リンクから `#poc-recruitment` へ遷移、PoC セクション可視時に `poc_section_view` 発火
- `header_poc_link_click` が GA4 リアルタイムに出る

## Risks / follow-ups

- `messages/{ja,en}.json` の `nav` ブロックに `technology / useCases / poc / contact / menuOpen / menuClose` を追加。既存キー (`product / cases / docs / whitepaper / pricing / security / demo`) は破壊していないが、`pricing` は `価格` → `料金` に統一（Header / Footer の表示で揺れがあったため）。Footer / 他コンポーネントで `nav.pricing` を参照している箇所への影響は表記のみで導線変更なし。
- Mobile メニューは body scroll lock を入れたが、Cookie banner / `MobileStickyCta` との重なりは要目視確認。
- `Try Demo` (`/recommendation-demo`) を Header から外したため、recommendation demo への流入は LP の Demo CTA と Footer 経由のみとなる。広告経由のデモ流入指標で問題が出ればセカンダリ導線の再追加を検討。

## b2b_sales notes

- `b2b_sales/docs/HIGH_VALUE_MODEL_USAGE_PLAN_20260427.md` T1 / T2 を更新（PR #22 merge済み + Header/Nav PR 着手 + IG Bio 最終確定）
- `b2b_sales/docs/SOGYO_GRANT_APPLICATION_STORY_V0.md` §4 LP/Webapp 行に Header/Nav 整理 + IG Bio link 確定を追記
- `b2b_sales/docs/IG_PROFILE_AND_PINNED_POST_V0.md` に「最終採用 Bio」「最終採用 Bio link」「差し替え手順」「UTM検証方法」を追記

## Next task

Header/Nav merge & production 反映後は **A. Meta 広告 creative 3 案（訴求 A / B / C）** を作成し、Track M 実験 v1 launch に向けた素材を整える（IG 固定投稿カルーセル実画像作成は B 候補として後続）。
